### PR TITLE
Use half of child population and half of parents.

### DIFF
--- a/GAOptimizer/population.py
+++ b/GAOptimizer/population.py
@@ -91,7 +91,7 @@ class population:
         for whichmember in range(self.nMembers):
             children.append(self.mate())
         children.sort(key=lambda member: member.fitness)
-        self._members = [self._members[:self.nMembers//2]] + children[:(self.nMembers+1)//2]
+        self._members = self._members[:self.nMembers//2] + children[:(self.nMembers+1)//2]
         self._members.sort(key=lambda member: member.fitness)
         self._generation += 1
 

--- a/GAOptimizer/population.py
+++ b/GAOptimizer/population.py
@@ -78,17 +78,21 @@ class population:
         #Mutate the child to widen parameters outside the parents
         child.mutate(self._bounds, 1.0/np.sqrt(self._generation+1))
         child._fitness = self._fitnessFunc(child.params)
-
-        if (child.__lt__(self._members[-1])):
-            self._members[-1] = child
+        return child
+        # if (child.__lt__(self._members[-1])):
+        #     self._members[-1] = child
         
-        self._members.sort(key=lambda member: member.fitness)
+        # self._members.sort(key=lambda member: member.fitness)
     
     def evolve(self):
         """Move the population forward a generation by creating population.nMembers new potential children.
         Whether children survive is determined by the population.mate() function."""
+        children = []
         for whichmember in range(self.nMembers):
-            self.mate()
+            children.append(self.mate())
+        children.sort(key=lambda member: member.fitness)
+        self._members = [self._members[:self.nMembers//2]] + children[:(self.nMembers+1)//2]
+        self._members.sort(key=lambda member: member.fitness)
         self._generation += 1
 
 


### PR DESCRIPTION
This PR changes the way that generations are created. Instead of creating a child, replacing the weakest parent, and resorting the population each time, it creates a population of children, sorts that population, and takes 50% of the parent and 50% of the child population.  This leads to far fewer sorts and may improve the spread of parameters.